### PR TITLE
136589065 - Add and localize apple health permissions description

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,12 +44,15 @@
     </config-file-->
 
     <!-- Usage description of Health, mandatory since iOS 10 -->
-    <config-file target="*-Info.plist" parent="NSHealthShareUsageDescription">
+    <!--config-file target="*-Info.plist" parent="NSHealthShareUsageDescription">
       <string/>
     </config-file>
     <config-file target="*-Info.plist" parent="NSHealthUpdateUsageDescription">
       <string/>
-    </config-file>
+    </config-file-->
+
+    <resource-file src="src/ios/en.lproj"/>
+    <resource-file src="src/ios/fr.lproj"/>
 
     <header-file src="src/ios/WorkoutActivityConversion.h"/>
     <source-file src="src/ios/WorkoutActivityConversion.m"/>

--- a/src/ios/translations/en.lproj/InfoPlist.strings
+++ b/src/ios/translations/en.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+{
+    NSHealthShareUsageDescription = "To sync and track your activity from Health, Sprout needs permission to read data.";
+}

--- a/src/ios/translations/fr.lproj/InfoPlist.strings
+++ b/src/ios/translations/fr.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+{
+    NSHealthShareUsageDescription = "Pour synchroniser et suivre votre activité à partir de Santé, Sprout a besoin d'une autorisation pour lire les données.";
+}


### PR DESCRIPTION
# Problem that this pull request is addressing
When asking the user for permissions to Apple Health, we need an explanation/description statement that is localized

# Solution
Added InfoPlist.strings files in localized directories and added lines to plugin.xml that place those files into the references folder of a project when ios is added.

# What is fixed in addition to that
N/A

# How it was tested
Tested on an iPod touch by going to the permissions request screen in both english and french to verify localization.

# What new text has been added and localized
I had previously added NSHealthShareUsageDescription when I attempted to fix this before

# Associated Pivotal Story
https://www.pivotaltracker.com/story/show/136589065